### PR TITLE
this repository now is public

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This document describes the contribution workflow, coding style, and review proc
 To build ORTEAF locally:
 
 ```bash
-git clone https://github.com/yourname/orteaf.git
+git clone https://github.com/WARE10sai/orteaf.git
 cd orteaf
 mkdir build && cd build
 cmake -G Ninja ..

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This framework serves as the backbone for the research and engineering required 
 
 ### Using CMake with Ninja
 ```bash
-git clone https://github.com/yourname/orteaf.git
+git clone https://github.com/WARE10sai/orteaf.git
 cd orteaf
 mkdir build && cd build
 cmake -G Ninja ..


### PR DESCRIPTION
This pull request updates the documentation to use the correct GitHub repository URL for cloning the project. Both the `CONTRIBUTING.md` and `README.md` files now instruct users to clone from the `WARE10sai/orteaf` repository instead of the placeholder `yourname/orteaf` repository.

Documentation updates:

* Updated the `git clone` command in `CONTRIBUTING.md` to use the correct repository URL.
* Updated the `git clone` command in `README.md` to use the correct repository URL.