### PR TITLE
test: ChunkLocator policies のテストカバレッジ向上

### DIFF
--- a/tests/internal/runtime/allocator/chunk_locator/mock_direct_chunk_locator.cpp
+++ b/tests/internal/runtime/allocator/chunk_locator/mock_direct_chunk_locator.cpp
@@ -54,6 +54,21 @@ TEST(DirectChunkLocator, ReleaseChunkCallsResourceWhenFree) {
     MockCpuResource::reset();
 }
 
+TEST(DirectChunkLocator, InitializeFailsWithNullResource) {
+    Policy policy;
+    Policy::Config cfg{};
+    cfg.device = 0;
+    cfg.context = 0;
+    cfg.stream = nullptr;
+
+    EXPECT_THROW(policy.initialize(cfg, nullptr), std::system_error);
+}
+
+TEST(DirectChunkLocator, AddChunkBeforeInitializeThrows) {
+    Policy policy;
+    EXPECT_THROW(policy.addChunk(64, 1), std::system_error);
+}
+
 TEST(DirectChunkLocator, ReleaseChunkSkipsWhenInUse) {
     Policy policy;
     MockCpuResource resource;
@@ -80,6 +95,31 @@ TEST(DirectChunkLocator, ReleaseChunkSkipsWhenInUse) {
 
     policy.decrementUsed(id);
     EXPECT_TRUE(policy.releaseChunk(id));
+
+    MockCpuResource::reset();
+}
+
+TEST(DirectChunkLocator, DoubleReleaseFails) {
+    Policy policy;
+    MockCpuResource resource;
+    Policy::Config cfg{};
+    cfg.device = 11;
+    cfg.context = 0;
+    cfg.stream = nullptr;
+
+    NiceMock<MockCpuResourceImpl> impl;
+    MockCpuResource::set(&impl);
+    policy.initialize(cfg, &resource);
+
+    CpuView view{reinterpret_cast<void*>(0x21), 0, 128};
+    EXPECT_CALL(impl, allocate(128, 1, 11, nullptr)).WillOnce(Return(view));
+    EXPECT_CALL(impl, deallocate(view, 128, 1, 11, nullptr)).Times(1);
+
+    auto block = policy.addChunk(128, 1);
+    BufferId id = block.id;
+    EXPECT_TRUE(policy.releaseChunk(id));
+    EXPECT_FALSE(policy.releaseChunk(id));
+    EXPECT_FALSE(policy.isAlive(id));
 
     MockCpuResource::reset();
 }
@@ -112,6 +152,29 @@ TEST(DirectChunkLocator, PendingBlocksPreventRelease) {
     MockCpuResource::reset();
 }
 
+TEST(DirectChunkLocator, OperationsOnInvalidIdAreNoops) {
+    Policy policy;
+    MockCpuResource resource;
+    Policy::Config cfg{};
+    cfg.device = 5;
+    cfg.context = 0;
+    cfg.stream = nullptr;
+
+    NiceMock<MockCpuResourceImpl> impl;
+    MockCpuResource::set(&impl);
+    policy.initialize(cfg, &resource);
+
+    BufferId invalid{99999};
+    policy.incrementUsed(invalid);
+    policy.decrementUsed(invalid);
+    policy.incrementPending(invalid);
+    policy.decrementPending(invalid);
+    policy.decrementPendingAndUsed(invalid);
+    EXPECT_FALSE(policy.isAlive(invalid));
+
+    MockCpuResource::reset();
+}
+
 TEST(DirectChunkLocator, FindChunkSizeReturnsRegisteredValue) {
     Policy policy;
     MockCpuResource resource;
@@ -130,6 +193,48 @@ TEST(DirectChunkLocator, FindChunkSizeReturnsRegisteredValue) {
     auto block = policy.addChunk(512, 1);
 
     EXPECT_EQ(policy.findChunkSize(block.id), 512u);
+
+    MockCpuResource::reset();
+}
+
+TEST(DirectChunkLocator, FindChunkSizeReturnsZeroForInvalidId) {
+    Policy policy;
+    MockCpuResource resource;
+    Policy::Config cfg{};
+    cfg.device = 6;
+    cfg.context = 0;
+    cfg.stream = nullptr;
+
+    NiceMock<MockCpuResourceImpl> impl;
+    MockCpuResource::set(&impl);
+    policy.initialize(cfg, &resource);
+
+    BufferId invalid{123456};
+    EXPECT_EQ(policy.findChunkSize(invalid), 0u);
+
+    MockCpuResource::reset();
+}
+
+TEST(DirectChunkLocator, IsAliveReflectsState) {
+    Policy policy;
+    MockCpuResource resource;
+    Policy::Config cfg{};
+    cfg.device = 7;
+    cfg.context = 0;
+    cfg.stream = nullptr;
+
+    NiceMock<MockCpuResourceImpl> impl;
+    MockCpuResource::set(&impl);
+    policy.initialize(cfg, &resource);
+
+    CpuView view{reinterpret_cast<void*>(0x70), 0, 64};
+    EXPECT_CALL(impl, allocate(64, 1, 7, nullptr)).WillOnce(Return(view));
+    EXPECT_CALL(impl, deallocate(view, 64, 1, 7, nullptr)).Times(1);
+
+    auto block = policy.addChunk(64, 1);
+    EXPECT_TRUE(policy.isAlive(block.id));
+    EXPECT_TRUE(policy.releaseChunk(block.id));
+    EXPECT_FALSE(policy.isAlive(block.id));
 
     MockCpuResource::reset();
 }


### PR DESCRIPTION
## Summary

- DirectChunkLocatorPolicy のエラー系テスト追加
  - `InitializeFailsWithNullResource`
  - `AddChunkBeforeInitializeThrows`
  - `DoubleReleaseFails`
  - `OperationsOnInvalidIdAreNoops`
  - `FindChunkSizeReturnsZeroForInvalidId`
  - `IsAliveReflectsState`

- HierarchicalChunkLocator のエラー系テスト追加
  - `InitializeCanBeCalledTwice`
  - `InitializeFailsWhenReserveThrows`
  - `AddChunkFailsWhenMapThrows`
  - `LevelsMustBeNonIncreasing`
  - `ThresholdValidationFailsForInvalidValues`
  - `IsAliveReflectsSlotState`

- DirectChunkLocatorPolicy のエラーハンドリング改善
  - `ORTEAF_THROW_IF_NULL` で null resource チェック
  - `ORTEAF_THROW_IF` で未初期化・ゼロサイズチェック

## Test plan

- [x] 全55テスト（ChunkLocator関連）がパス
- [x] ビルド成功

Closes #44